### PR TITLE
Refactor matching test helpers to LineMatcher.

### DIFF
--- a/src/main/java/toyrobotsimulator/LineMatcher.java
+++ b/src/main/java/toyrobotsimulator/LineMatcher.java
@@ -1,0 +1,41 @@
+package toyrobotsimulator;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class LineMatcher {
+
+	private final String regexStartAnchor = "^"; 
+	
+	public boolean isFirstIn(final String string, final String content) {
+		return contentMatchesPattern(content, firstLine(string));
+	}
+
+	private boolean contentMatchesPattern(final String content, final Pattern pattern) {
+		return matcherForPatternWith(pattern, content).find();
+	}
+
+	private Matcher matcherForPatternWith(final Pattern pattern, final String content) {
+		return pattern.matcher(content);
+	}
+	
+	private Pattern firstLine(final String string) {
+		return linePatternWith(regexStart(string));
+	}
+
+	private String regexStart(final String string) {
+		return regexStartAnchor + string;
+	}
+	
+	private Pattern linePatternWith(final String string) {
+		return Pattern.compile(lineWith(string));
+	}
+
+	private String lineWith(final String string) {
+		return string + System.lineSeparator();
+	}
+
+	public boolean containsIn(final String string, final String content) {
+		return content.contains(lineWith(string));
+	}
+}

--- a/src/main/java/toyrobotsimulator/RobotCommand.java
+++ b/src/main/java/toyrobotsimulator/RobotCommand.java
@@ -1,0 +1,9 @@
+package toyrobotsimulator;
+
+public class RobotCommand {
+
+	public RobotCommand(final String string) {
+		// TODO Auto-generated constructor stub
+	}
+
+}

--- a/src/main/java/toyrobotsimulator/RobotCommands.java
+++ b/src/main/java/toyrobotsimulator/RobotCommands.java
@@ -1,0 +1,29 @@
+package toyrobotsimulator;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RobotCommands {
+	
+	private static RobotCommand robotCommandFromString(final String command) {
+		return new RobotCommand(command);
+	}
+	
+	private List<RobotCommand> commands;
+	
+	public RobotCommands(final String ... commands) {
+		this(Arrays.asList(commands).stream()
+				.map(RobotCommands::robotCommandFromString)
+				.collect(Collectors.toList()));
+	}
+	
+	public RobotCommands(final RobotCommand ... commands) {
+		this(Arrays.asList(commands));
+	}
+	
+	public RobotCommands(final List<RobotCommand> commands) {
+		this.commands = new ArrayList<RobotCommand>(commands);
+	}
+}

--- a/src/main/java/toyrobotsimulator/ToyRobotSimulation.java
+++ b/src/main/java/toyrobotsimulator/ToyRobotSimulation.java
@@ -13,8 +13,13 @@ public class ToyRobotSimulation implements Simulation {
 	public void run() {
 		printStream.println("Running");
 		printStream.println("Not placed");
+		printStream.println("0,0,EAST");
 	}
 
-	public void enterCommand(final String command) {
+	public void enterCommand(final RobotCommand command) {
+	}
+
+	public void enterCommands(final RobotCommands commands) {
+		
 	}
 }

--- a/src/test/java/toyrobotsimulator/MatcherTest.java
+++ b/src/test/java/toyrobotsimulator/MatcherTest.java
@@ -1,0 +1,59 @@
+package toyrobotsimulator;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class MatcherTest {
+
+	private LineMatcher lineMatcher;
+	private String line1Content;
+	private String line2Content;
+	private String lines;
+	private String lineContentNotInLines;
+	
+	@Before
+	public void setUp() throws Exception {
+		lineMatcher = new LineMatcher();
+		line1Content = "line 1";
+		line2Content = "line 2";
+		lineContentNotInLines = "not in lines";
+		createLinesString(line1Content, line2Content);
+	}
+	
+	/**
+	 * Each line in lineList is concatenated with line separators to create a string such that
+	 * ["l1", "l2"] -> "l1" + separator + "l2" + separator
+	 */
+	private void createLinesString(final String ... lineList) {
+		String newLine = System.lineSeparator();
+		lines = Arrays.asList(lineList)
+				.stream()
+				.collect(Collectors.joining(/* delimiter */newLine, /*prefix*/"", /* suffix */newLine));
+	}
+	
+	@Test
+	public void Line1IsTheFirstLineInLines() {
+		assertTrue(lineMatcher.isFirstIn(line1Content, lines));
+	}
+	
+	@Test
+	public void Line2IsNotTheFirstLineInLines() {
+		assertFalse(lineMatcher.isFirstIn(line2Content, lines));
+	}
+	
+	@Test
+	public void LinesContainsLine2() {
+		assertTrue(lineMatcher.containsIn(line2Content, lines));
+	}
+	
+	@Test
+	public void LinesDoesNotContainLineThatIsNotInLines() {
+		assertFalse(lineMatcher.containsIn(lineContentNotInLines, lines));
+	}
+}


### PR DESCRIPTION
This was supposed to only include refactoring the matching helpers into a new class. I forgot I had started working on adding the `RobotCommand` and `RobotCommands` classes and the `enterCommand`/`enterCommands` method to the `ToyRobotSimulation`, so it includes that as well.

I decided that the simulation output is expected to be in lines, so the matcher is a "line matcher". You give it a string and it verifies that the string is a line in the content. I think it matches what we were testing a little better than what I started with. What do you think?

I had created some methods in `ToyRobotSimulationTest` that created `RobotCommands` from a variable length parameter list `(String ... commands)`. It made it easier to create the commands for the test. I figured since there was a need to create `RobotCommands` like this, then maybe it should be a constructor. I made a constructor that does this, but I don't have a test that verifies the parameter list conversion I did works. I'm wondering what is the correct way to test this, or was this a good idea at all?
