### PR TITLE
Simulation enter commands alt

### DIFF
--- a/src/main/java/toyrobotsimulator/RobotCommandAction.java
+++ b/src/main/java/toyrobotsimulator/RobotCommandAction.java
@@ -1,0 +1,6 @@
+package toyrobotsimulator;
+
+public interface RobotCommandAction {
+
+	void actionWith(final RobotCommand robotCommand);
+}

--- a/src/main/java/toyrobotsimulator/RobotCommands.java
+++ b/src/main/java/toyrobotsimulator/RobotCommands.java
@@ -19,6 +19,10 @@ public class RobotCommands {
 	
 	private List<RobotCommand> commands;
 	
+	public RobotCommands() {
+		this(new ArrayList<>());
+	}
+	
 	public RobotCommands(final String ... commands) {
 		this(robotCommandsFromStrings(commands));
 	}
@@ -34,5 +38,13 @@ public class RobotCommands {
 	public void eachDo(final RobotCommandAction robotCommandAction) {
 		commands.stream()
 			.forEachOrdered((command) -> robotCommandAction.actionWith(command));
+	}
+
+	public void add(final RobotCommand command) {
+		commands.add(command);		
+	}
+
+	public void add(final RobotCommands addedCommands) {
+		addedCommands.eachDo((command) -> add(command));
 	}
 }

--- a/src/main/java/toyrobotsimulator/RobotCommands.java
+++ b/src/main/java/toyrobotsimulator/RobotCommands.java
@@ -30,4 +30,9 @@ public class RobotCommands {
 	public RobotCommands(final List<RobotCommand> commands) {
 		this.commands = new ArrayList<RobotCommand>(commands);
 	}
+
+	public void eachDo(final RobotCommandAction robotCommandAction) {
+		commands.stream()
+			.forEachOrdered((command) -> robotCommandAction.actionWith(command));
+	}
 }

--- a/src/main/java/toyrobotsimulator/ToyRobotSimulation.java
+++ b/src/main/java/toyrobotsimulator/ToyRobotSimulation.java
@@ -17,9 +17,10 @@ public class ToyRobotSimulation implements Simulation {
 	}
 
 	public void enterCommand(final RobotCommand command) {
+		
 	}
 
 	public void enterCommands(final RobotCommands commands) {
-		
+		commands.eachDo((command) -> enterCommand(command));
 	}
 }

--- a/src/main/java/toyrobotsimulator/ToyRobotSimulation.java
+++ b/src/main/java/toyrobotsimulator/ToyRobotSimulation.java
@@ -5,10 +5,16 @@ import java.io.PrintStream;
 public class ToyRobotSimulation implements Simulation {
 
 	private final PrintStream printStream;
+	private final RobotCommands robotCommands;
+	
+	public ToyRobotSimulation(final PrintStream printStream, final RobotCommands robotCommands) {
+		this.printStream = printStream;
+		this.robotCommands = robotCommands;
+	}
 	
 	public ToyRobotSimulation(final PrintStream printStream) {
-		this.printStream = printStream;
-	}
+		this(printStream, new RobotCommands());
+	} 
 	
 	public void run() {
 		printStream.println("Running");
@@ -17,10 +23,10 @@ public class ToyRobotSimulation implements Simulation {
 	}
 
 	public void enterCommand(final RobotCommand command) {
-		
+		robotCommands.add(command);
 	}
 
 	public void enterCommands(final RobotCommands commands) {
-		commands.eachDo((command) -> enterCommand(command));
+		robotCommands.add(commands);
 	}
 }

--- a/src/test/java/toyrobotsimulator/RobotCommandsTest.java
+++ b/src/test/java/toyrobotsimulator/RobotCommandsTest.java
@@ -15,29 +15,57 @@ import org.mockito.runners.MockitoJUnitRunner;
 public class RobotCommandsTest {
 
 	private RobotCommands robotCommands;
+	@Mock
 	private RobotCommand command1;
+	@Mock
 	private RobotCommand command2;
 	@Mock
 	private RobotCommandAction robotCommandAction;
 
+	private void createCommandsWith(final RobotCommand... commands) {
+		robotCommands = new RobotCommands(commands);
+	}
+	
+	private void createEmptyCommands() {
+		robotCommands = new RobotCommands();
+	}
+	
 	@Before
 	public void setUp() throws Exception {
-		command1 = new RobotCommand("command1");
-		command2 = new RobotCommand("command2");
-		robotCommands = new RobotCommands(command1, command2);
 	}
 
+	private void verifyCommandsInOrder(final RobotCommand ... commands) {
+		robotCommands.eachDo(robotCommandAction);
+		InOrder inOrder = inOrder(robotCommandAction);
+		for(RobotCommand command : commands)
+			inOrder.verify(robotCommandAction).actionWith(command);
+	}
+	
 	@Test
 	public void WhenEachDo_With2Commands_RunsActionExactlyTwice() {
+		createCommandsWith(command1, command2);
 		robotCommands.eachDo(robotCommandAction);
 		verify(robotCommandAction, times(2)).actionWith(isA(RobotCommand.class));
 	}
 	
 	@Test
 	public void WhenEachDo_RunsAction_InCorrectOrder() {
-		robotCommands.eachDo(robotCommandAction);
-		 InOrder inOrder = inOrder(robotCommandAction);
-		 inOrder.verify(robotCommandAction).actionWith(command1);
-		 inOrder.verify(robotCommandAction).actionWith(command2);
+		createCommandsWith(command1, command2);
+		verifyCommandsInOrder(command1, command2);
+	}
+	
+	@Test
+	public void WhenAdd_CommandsAreAddedInOrder() {
+		createEmptyCommands();
+		robotCommands.add(command1);
+		robotCommands.add(command2);
+		verifyCommandsInOrder(command1, command2);
+	}
+	
+	@Test
+	public void WhenAddCommands_CommandsAreAddedInOrder() {
+		createEmptyCommands();
+		robotCommands.add(new RobotCommands(command1, command2));
+		verifyCommandsInOrder(command1, command2);
 	}
 }

--- a/src/test/java/toyrobotsimulator/RobotCommandsTest.java
+++ b/src/test/java/toyrobotsimulator/RobotCommandsTest.java
@@ -1,0 +1,43 @@
+package toyrobotsimulator;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RobotCommandsTest {
+
+	private RobotCommands robotCommands;
+	private RobotCommand command1;
+	private RobotCommand command2;
+	@Mock
+	private RobotCommandAction robotCommandAction;
+
+	@Before
+	public void setUp() throws Exception {
+		command1 = new RobotCommand("command1");
+		command2 = new RobotCommand("command2");
+		robotCommands = new RobotCommands(command1, command2);
+	}
+
+	@Test
+	public void WhenEachDo_With2Commands_RunsActionExactlyTwice() {
+		robotCommands.eachDo(robotCommandAction);
+		verify(robotCommandAction, times(2)).actionWith(isA(RobotCommand.class));
+	}
+	
+	@Test
+	public void WhenEachDo_RunsActionExactly_InCorrectOrder() {
+		robotCommands.eachDo(robotCommandAction);
+		 InOrder inOrder = inOrder(robotCommandAction);
+		 inOrder.verify(robotCommandAction).actionWith(command1);
+		 inOrder.verify(robotCommandAction).actionWith(command2);
+	}
+}

--- a/src/test/java/toyrobotsimulator/RobotCommandsTest.java
+++ b/src/test/java/toyrobotsimulator/RobotCommandsTest.java
@@ -34,7 +34,7 @@ public class RobotCommandsTest {
 	}
 	
 	@Test
-	public void WhenEachDo_RunsActionExactly_InCorrectOrder() {
+	public void WhenEachDo_RunsAction_InCorrectOrder() {
 		robotCommands.eachDo(robotCommandAction);
 		 InOrder inOrder = inOrder(robotCommandAction);
 		 inOrder.verify(robotCommandAction).actionWith(command1);

--- a/src/test/java/toyrobotsimulator/ToyRobotSimulationIntegrationTest.java
+++ b/src/test/java/toyrobotsimulator/ToyRobotSimulationIntegrationTest.java
@@ -8,7 +8,7 @@ import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ToyRobotSimulationTest {
+public class ToyRobotSimulationIntegrationTest {
 
 	private ToyRobotSimulation toyRobotSimulation;
 	private CapturingPrintStream capturingPrintStream;

--- a/src/test/java/toyrobotsimulator/ToyRobotSimulationUnitTest.java
+++ b/src/test/java/toyrobotsimulator/ToyRobotSimulationUnitTest.java
@@ -1,0 +1,42 @@
+package toyrobotsimulator;
+
+import static org.mockito.Mockito.verify;
+
+import java.io.PrintStream;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ToyRobotSimulationUnitTest {
+
+	private ToyRobotSimulation toyRobotSimulation;
+	@Mock
+	private PrintStream printStream;
+	@Mock
+	private RobotCommands simulationCommands;
+	@Mock
+	private RobotCommand aRobotCommand;
+	@Mock
+	private RobotCommands commands;
+	
+	@Before
+	public void setUp() throws Exception {
+		toyRobotSimulation = new ToyRobotSimulation(printStream, simulationCommands);
+	}
+	
+	@Test
+	public void EnteringACommand_AddsTheCommandToTheCommands() {
+		toyRobotSimulation.enterCommand(aRobotCommand);
+		verify(simulationCommands).add(aRobotCommand);
+	}
+	
+	@Test
+	public void EnteringCommands_AddsTheCommandsToTheCommands() {
+		toyRobotSimulation.enterCommands(commands);
+		verify(simulationCommands).add(commands);
+	}
+}


### PR DESCRIPTION
I found some of the code I was writing wasn't unit tested, like `ToyRobotSimulation::enterCommand` methods. I made a file for `ToyRobotSimulation` unit tests and another for integration tests. This is just until I find a way to separate them into other packages and run them separately. Not sure if any of this is good.

The `RobotCommands` tests using the actual `RobotCommands` to do some verification in `verifyCommandsInOrder`. Not sure if this is a good practice. Didn't know a better way.
